### PR TITLE
Include implementations of BaseRepository

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,15 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL Scan
 
 on:
   push:
@@ -21,8 +10,12 @@ on:
     - cron: '43 3 * * 3'
 
 jobs:
-  analyze:
-    name: Analyze
+  codeql-analysis:
+    # ↓ Change this to "false" to disable the workflow without any alert messages.
+    if: ${{ true }}
+    # ↑ Change to "true" (or delete) to enable the workflow.
+
+    name: Analyze with CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -32,14 +25,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        language: ["csharp"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-      - name: Checkout repository
+      - name: Check out repository
         uses: actions/checkout@v3
-      
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -48,22 +41,26 @@ jobs:
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
-          
+
           # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
-      
-      
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: global.json
+
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2
-      
+
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      
-      #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
       #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-      
+
       # - run: |
       #   echo "Run, Build Application using script"
       #   ./location_of_script_within_repo/buildscript.sh

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,27 +1,33 @@
-name: .NET Test
+name: .NET Unit Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
 
 jobs:
-  build:
-
-    if: github.event.pull_request.draft == false
-
-    runs-on: ubuntu-latest
-
+  dotnet-test:
+    # ↓ Change this to "false" to disable the workflow without any alert messages.
+    if: ${{ true }}
+    # ↑ Change to "true" (or delete) to enable the workflow.
+    
+    name: Run unit tests
+    runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@v3
+
       - name: Set up .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          global-json-file: global.json
+
       - name: Restore dependencies
         run: dotnet restore
+
       - name: Build
         run: dotnet build --no-restore
+
       - name: Test
         run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/publish-nuget-package.yml
+++ b/.github/workflows/publish-nuget-package.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          global-json-file: global.json
 
       - name: Build and pack
         run: dotnet build --configuration Release

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -1,45 +1,63 @@
-name: Scan with SonarCloud
+name: SonarCloud Scan
+
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
   pull_request:
     types: [opened, synchronize, reopened]
+
 jobs:
-  build:
-    name: Build
+  sonarcloud-scan:
+    # ↓ Change this to "false" to disable the workflow without any alert messages.
+    if: ${{ true }}
+    # ↑ Change to "true" (or delete) to enable the workflow.
+
+    name: Analyze with SonarCloud
     runs-on: windows-latest
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up Java JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.11
-      - uses: actions/checkout@v2
+          java-version: 17
+          distribution: "zulu" # Alternative distribution options are available.
+
+      - name: Check out repository
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Set up .NET 6
-        uses: actions/setup-dotnet@v1
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          global-json-file: global.json
+
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
+
       - name: Install SonarCloud scanner
         if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+
+      - name: Install Coverlet as global dotnet tool
+        shell: powershell
+        run: |
+          dotnet tool install --global coverlet.console
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any

--- a/.idea/.idea.GaEpd.AppLibrary/.idea/indexLayout.xml
+++ b/.idea/.idea.GaEpd.AppLibrary/.idea/indexLayout.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="UserContentModel">
     <attachedFolders>
-      <Path>.github</Path>
+      <Path>.github/workflows</Path>
     </attachedFolders>
     <explicitIncludes />
     <explicitExcludes />

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+v3.4.0
+
+- Included abstract implementations of BaseRepository.
+
 v3.3.0
 
 - Added a "ConcatWithSeparator" string extension.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ public record Address : ValueObject
 
 Note: The `[Owned]` attribute is an Entity Framework attribute defining this as a value object owned by the parent class. See [Owned Entity Types](https://learn.microsoft.com/en-us/ef/core/modeling/owned-entities) for more info on how this is implemented in EF Core.
 
-### Repository interfaces
+### Data Repositories
 
-Common repository interfaces define basic entity CRUD operations. The `IReadRepository<TEntity, in TKey>` interface defines get and search operations (including paginated search). The `IWriteRepository<TEntity, in TKey>` interface defines insert, update, and delete operations. `IRepository<TEntity, in TKey>` combines the read and write interfaces.
+Common data repository interfaces define basic entity CRUD operations. The `IReadRepository<TEntity, in TKey>` interface defines get and search operations (including paginated search). The `IWriteRepository<TEntity, in TKey>` interface defines insert, update, and delete operations. `IRepository<TEntity, in TKey>` combines the read and write interfaces.
 
-Note that these interfaces work directly with domain entities. Your application should define [application/domain services](https://docs.abp.io/en/abp/latest/Domain-Services#application-services-vs-domain-services) that define how the application interacts with the entities & repositories through data transfer objects (DTOs).  
+(Note that these interfaces work directly with domain entities. Your application should define [application/domain services](https://docs.abp.io/en/abp/latest/Domain-Services#application-services-vs-domain-services) that define how the application interacts with the entities & repositories through data transfer objects (DTOs).)
+
+There are two abstract `BaseRepository` classes that each implement the `IRepository` interface, one using in-memory data and the other requiring an Entity Framework database context.
 
 ### Predicate builder
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "7.0.0",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/Domain/Repositories/EFRepository/BaseRepository.cs
+++ b/src/Domain/Repositories/EFRepository/BaseRepository.cs
@@ -1,0 +1,110 @@
+﻿using GaEpd.AppLibrary.Domain.Entities;
+using GaEpd.AppLibrary.Pagination;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+
+namespace GaEpd.AppLibrary.Domain.Repositories.EFRepository;
+
+public abstract class BaseRepository<TEntity, TKey> : IRepository<TEntity, TKey>
+    where TEntity : class, IEntity<TKey>
+    where TKey : IEquatable<TKey>
+{
+    public readonly DbContext Context;
+
+    protected BaseRepository(DbContext context) => Context = context;
+
+    public async Task<TEntity> GetAsync(TKey id, CancellationToken token = default) =>
+        await Context.Set<TEntity>().SingleOrDefaultAsync(e => e.Id.Equals(id), token)
+        ?? throw new EntityNotFoundException(typeof(TEntity), id);
+
+    public Task<TEntity?> FindAsync(TKey id, CancellationToken token = default) =>
+        Context.Set<TEntity>().AsNoTracking().SingleOrDefaultAsync(e => e.Id.Equals(id), token);
+
+    public Task<TEntity?> FindAsync(
+        Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        Context.Set<TEntity>().AsNoTracking().SingleOrDefaultAsync(predicate, token);
+
+    public async Task<IReadOnlyCollection<TEntity>> GetListAsync(CancellationToken token = default) =>
+        await Context.Set<TEntity>().AsNoTracking().ToListAsync(token);
+
+    public async Task<IReadOnlyCollection<TEntity>> GetListAsync(
+        Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        await Context.Set<TEntity>().AsNoTracking().Where(predicate).ToListAsync(token);
+
+    public async Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(
+        Expression<Func<TEntity, bool>> predicate, PaginatedRequest paging, CancellationToken token = default) =>
+        await Context.Set<TEntity>().AsNoTracking().Where(predicate)
+            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToListAsync(token);
+
+    public async Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(
+        PaginatedRequest paging, CancellationToken token = default) =>
+        await Context.Set<TEntity>().AsNoTracking()
+            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToListAsync(token);
+
+    public Task<int> CountAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        Context.Set<TEntity>().AsNoTracking().CountAsync(predicate, token);
+
+    public Task<bool> ExistsAsync(TKey id, CancellationToken token = default) =>
+        Context.Set<TEntity>().AsNoTracking().AnyAsync(e => e.Id.Equals(id), token);
+
+    public Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        Context.Set<TEntity>().AsNoTracking().AnyAsync(predicate, token);
+
+    public async Task InsertAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
+    {
+        await Context.Set<TEntity>().AddAsync(entity, token);
+        if (autoSave) await SaveChangesAsync(token);
+    }
+
+    public async Task UpdateAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
+    {
+        Context.Attach(entity);
+        Context.Update(entity);
+
+        if (!autoSave) return;
+
+        try
+        {
+            await SaveChangesAsync(token);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            if (!await Context.Set<TEntity>().AsNoTracking().AnyAsync(e => e.Id.Equals(entity.Id), token))
+                throw new EntityNotFoundException(typeof(TEntity), entity.Id);
+            throw;
+        }
+    }
+
+    public async Task DeleteAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
+    {
+        Context.Set<TEntity>().Remove(entity);
+
+        try
+        {
+            if (autoSave) await SaveChangesAsync(token);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            if (!await Context.Set<TEntity>().AsNoTracking().AnyAsync(e => e.Id.Equals(entity.Id), token))
+            {
+                throw new EntityNotFoundException(typeof(TEntity), entity.Id);
+            }
+
+            throw;
+        }
+    }
+
+    public async Task SaveChangesAsync(CancellationToken token = default) => await Context.SaveChangesAsync(token);
+
+    // ReSharper disable once VirtualMemberNeverOverridden.Global
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing) Context.Dispose();
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Domain/Repositories/IReadRepository.cs
+++ b/src/Domain/Repositories/IReadRepository.cs
@@ -39,9 +39,7 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <exception cref="InvalidOperationException">Thrown if there are multiple matches.</exception>
     /// <returns>An entity or null.</returns>
-    Task<TEntity?> FindAsync(
-        Expression<Func<TEntity, bool>> predicate,
-        CancellationToken token = default);
+    Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default);
 
     /// <summary>
     /// Returns a read-only collection of all <see cref="IEntity{TKey}"/> values.
@@ -82,9 +80,7 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable
     /// <param name="paging">A <see cref="PaginatedRequest"/> to define the paging options.</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A sorted and paged read-only collection of entities.</returns>
-    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(
-        PaginatedRequest paging,
-        CancellationToken token = default);
+    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging, CancellationToken token = default);
 
     /// <summary>
     /// Returns the count of <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.

--- a/src/Domain/Repositories/LocalRepository/BaseRepository.cs
+++ b/src/Domain/Repositories/LocalRepository/BaseRepository.cs
@@ -1,0 +1,97 @@
+﻿using GaEpd.AppLibrary.Domain.Entities;
+using GaEpd.AppLibrary.Pagination;
+using System.Linq.Expressions;
+
+namespace GaEpd.AppLibrary.Domain.Repositories.LocalRepository;
+
+public abstract class BaseRepository<TEntity, TKey> : IRepository<TEntity, TKey>
+    where TEntity : IEntity<TKey>
+    where TKey : IEquatable<TKey>
+{
+    public ICollection<TEntity> Items { get; }
+
+    protected BaseRepository(IEnumerable<TEntity> items) => Items = items.ToList();
+
+    public Task<TEntity> GetAsync(TKey id, CancellationToken token = default) =>
+        Items.Any(e => e.Id.Equals(id))
+            ? Task.FromResult(Items.Single(e => e.Id.Equals(id)))
+            : throw new EntityNotFoundException(typeof(TEntity), id);
+
+    public Task<TEntity?> FindAsync(TKey id, CancellationToken token = default) =>
+        Task.FromResult(Items.SingleOrDefault(e => e.Id.Equals(id)));
+
+    public Task<TEntity?> FindAsync(
+        Expression<Func<TEntity, bool>> predicate,
+        CancellationToken token = default) =>
+        Task.FromResult(Items.SingleOrDefault(predicate.Compile()));
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(CancellationToken token = default) =>
+        Task.FromResult(Items.ToList() as IReadOnlyCollection<TEntity>);
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(
+        Expression<Func<TEntity, bool>> predicate,
+        CancellationToken token = default) =>
+        Task.FromResult(Items.Where(predicate.Compile()).ToList() as IReadOnlyCollection<TEntity>);
+
+    public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(
+        Expression<Func<TEntity, bool>> predicate,
+        PaginatedRequest paging,
+        CancellationToken token = default)
+    {
+        var result = Items.Where(predicate.Compile()).AsQueryable()
+            .OrderByIf(paging.Sorting)
+            .Skip(paging.Skip).Take(paging.Take);
+        return Task.FromResult(result.ToList() as IReadOnlyCollection<TEntity>);
+    }
+
+    public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(
+        PaginatedRequest paging,
+        CancellationToken token = default)
+    {
+        var result = Items.AsQueryable()
+            .OrderByIf(paging.Sorting)
+            .Skip(paging.Skip).Take(paging.Take);
+        return Task.FromResult(result.ToList() as IReadOnlyCollection<TEntity>);
+    }
+
+    public Task<int> CountAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        Task.FromResult(Items.Count(predicate.Compile()));
+
+    public Task<bool> ExistsAsync(TKey id, CancellationToken token = default) =>
+        Task.FromResult(Items.Any(e => e.Id.Equals(id)));
+
+    public Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        Task.FromResult(Items.Any(predicate.Compile()));
+
+    public Task InsertAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
+    {
+        Items.Add(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task UpdateAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
+    {
+        var item = await GetAsync(entity.Id, token);
+        Items.Remove(item);
+        Items.Add(entity);
+    }
+
+    public async Task DeleteAsync(TEntity entity, bool autoSave = true, CancellationToken token = default) =>
+        Items.Remove(await GetAsync(entity.Id, token));
+
+    // Local repository does not require changes to be explicitly saved.
+    public Task SaveChangesAsync(CancellationToken token = default) => Task.CompletedTask;
+
+    // ReSharper disable once VirtualMemberNeverOverridden.Global
+    // ReSharper disable once UnusedParameter.Global
+    protected virtual void Dispose(bool disposing)
+    {
+        // This method intentionally left blank.
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/GaEpd.AppLibrary.csproj
+++ b/src/GaEpd.AppLibrary.csproj
@@ -40,14 +40,16 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.11" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.56.0.67649">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="9.9.0.77355">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.2" />
+        <PackageReference Include="System.Linq.Dynamic.Core" Version="1.3.4" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
+
 
     <Target Name="PrepareReleaseNotes" BeforeTargets="GenerateNuspec">
         <ReadLinesFromFile File="../CHANGELOG.txt">

--- a/tests/Extensions/EnumExtensions.cs
+++ b/tests/Extensions/EnumExtensions.cs
@@ -1,8 +1,7 @@
-﻿using FluentAssertions;
-using GaEpd.AppLibrary.Extensions;
+﻿using GaEpd.AppLibrary.Extensions;
 using System.ComponentModel.DataAnnotations;
 
-namespace GaEpd.AppLibrary.Tests.Enums;
+namespace GaEpd.AppLibrary.Tests.Extensions;
 
 [TestFixture]
 public class EnumExtensions

--- a/tests/Extensions/StringExtensions.cs
+++ b/tests/Extensions/StringExtensions.cs
@@ -1,7 +1,6 @@
-﻿using FluentAssertions;
-using GaEpd.AppLibrary.Extensions;
+﻿using GaEpd.AppLibrary.Extensions;
 
-namespace GaEpd.AppLibrary.Tests.Enums;
+namespace GaEpd.AppLibrary.Tests.Extensions;
 
 [TestFixture]
 public class StringExtensions

--- a/tests/GaEpd.AppLibrary.Tests.csproj
+++ b/tests/GaEpd.AppLibrary.Tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="EfCore.TestSupport" Version="5.3.0" />
         <PackageReference Include="FluentAssertions" Version="6.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />

--- a/tests/GlobalUsings.cs
+++ b/tests/GlobalUsings.cs
@@ -1,1 +1,3 @@
+global using FluentAssertions;
+global using FluentAssertions.Execution;
 global using NUnit.Framework;

--- a/tests/GuardTests/NotNegative.cs
+++ b/tests/GuardTests/NotNegative.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/GuardTests/NotNull.cs
+++ b/tests/GuardTests/NotNull.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/GuardTests/NotNullOrWhiteSpace.cs
+++ b/tests/GuardTests/NotNullOrWhiteSpace.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/GuardTests/Positive.cs
+++ b/tests/GuardTests/Positive.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/GuardTests/RegexMatch.cs
+++ b/tests/GuardTests/RegexMatch.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/GuardTests/ValidLength.cs
+++ b/tests/GuardTests/ValidLength.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using GaEpd.AppLibrary.GuardClauses;
 
 namespace GaEpd.AppLibrary.Tests.GuardTests;

--- a/tests/PaginationTests/PaginatedRequestTests.cs
+++ b/tests/PaginationTests/PaginatedRequestTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using GaEpd.AppLibrary.Pagination;
+﻿using GaEpd.AppLibrary.Pagination;
 
 namespace GaEpd.AppLibrary.Tests.PaginationTests;
 

--- a/tests/PaginationTests/PaginatedResultTests.cs
+++ b/tests/PaginationTests/PaginatedResultTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using GaEpd.AppLibrary.Pagination;
+﻿using GaEpd.AppLibrary.Pagination;
 
 namespace GaEpd.AppLibrary.Tests.PaginationTests;
 

--- a/tests/Repositories/EfRepositoryTestHelper.cs
+++ b/tests/Repositories/EfRepositoryTestHelper.cs
@@ -1,0 +1,143 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories.EFRepository;
+using Microsoft.EntityFrameworkCore;
+using System.Runtime.CompilerServices;
+using TestSupport.EfHelpers;
+
+namespace GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+public class EfRepository : BaseRepository<TestEntity, Guid>
+{
+    public EfRepository(DbContext context) : base(context) { }
+}
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<TestEntity> TestEntities => Set<TestEntity>();
+}
+
+public sealed class EfRepositoryTestHelper : IDisposable
+{
+    private AppDbContext Context { get; set; } = default!;
+    private readonly DbContextOptions<AppDbContext> _options;
+    private readonly AppDbContext _context;
+
+    /// <summary>
+    /// Constructor used by <see cref="CreateRepositoryHelper"/>.
+    /// </summary>
+    private EfRepositoryTestHelper()
+    {
+        _options = SqliteInMemory.CreateOptions<AppDbContext>();
+        _context = new AppDbContext(_options);
+        _context.Database.EnsureCreated();
+    }
+
+    /// <summary>
+    /// Constructor used by <see cref="CreateSqlServerRepositoryHelper"/>.
+    /// </summary>
+    /// <param name="callingClass">The class of the unit test method requesting the Repository Helper.</param>
+    /// <param name="callingMember">The unit test method requesting the Repository Helper.</param>
+    private EfRepositoryTestHelper(object callingClass, string callingMember)
+    {
+        _options = callingClass.CreateUniqueMethodOptions<AppDbContext>(callingMember: callingMember,
+            builder: opts => opts.UseSqlServer());
+        _context = new AppDbContext(_options);
+        _context.Database.EnsureClean();
+    }
+
+    /// <summary>
+    /// Creates a new Sqlite database and returns a RepositoryHelper.
+    /// </summary>
+    /// <example>
+    /// <para>
+    /// Create an instance of a <c>RepositoryHelper</c> and a <c>Repository</c> like this:
+    /// </para>
+    /// <code>
+    /// using var repositoryHelper = RepositoryHelper.CreateRepositoryHelper();
+    /// using var repository = repositoryHelper.GetOfficeRepository();
+    /// </code>
+    /// </example>
+    /// <returns>An <see cref="EfRepositoryTestHelper"/> with an empty Sqlite database.</returns>
+    public static EfRepositoryTestHelper CreateRepositoryHelper() => new();
+
+    /// <summary>
+    /// <para>
+    /// Creates a SQL Server database and returns a RepositoryHelper. Use of this method requires that
+    /// an "appsettings.json" exists in the project root with a connection string named "UnitTestConnection".
+    /// </para>
+    /// <para>
+    /// (The "<c>callingClass</c>" and "<c>callingMember</c>" parameters are used to generate a unique
+    /// database for each unit test method.)
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <para>
+    /// Create an instance of a <c>RepositoryHelper</c> and a <c>Repository</c> like this:
+    /// </para>
+    /// <code>
+    /// using var repositoryHelper = RepositoryHelper.CreateSqlServerRepositoryHelper(this);
+    /// using var repository = repositoryHelper.GetOfficeRepository();
+    /// </code>
+    /// </example>
+    /// <param name="callingClass">
+    /// Enter "<c>this</c>". The class of the unit test method requesting the Repository Helper.
+    /// </param>
+    /// <param name="callingMember">
+    /// Do not enter. The unit test method requesting the Repository Helper. This is filled in by the compiler.
+    /// </param>
+    /// <returns>A <see cref="EfRepositoryTestHelper"/> with a clean SQL Server database.</returns>
+    public static EfRepositoryTestHelper CreateSqlServerRepositoryHelper(
+        object callingClass, [CallerMemberName] string callingMember = "") =>
+        new(callingClass, callingMember);
+
+    /// <summary>
+    /// Stops tracking all currently tracked entities.
+    /// ReSharper disable once CommentTypo
+    /// See https://github.com/JonPSmith/EfCore.TestSupport/wiki/Using-SQLite-in-memory-databases#1-best-approach-one-instance-and-use-changetrackerclear
+    /// </summary>
+    public void ClearChangeTracker() => Context.ChangeTracker.Clear();
+
+    /// <summary>
+    /// Deletes all data from the EF database table for the specified entity.
+    /// </summary>
+    /// <typeparam name="TEntity">The entity whose data is to be deleted.</typeparam>
+    private async Task ClearTableAsync<TEntity>() where TEntity : class
+    {
+        Context.RemoveRange(Context.Set<TEntity>());
+        await Context.SaveChangesAsync();
+        ClearChangeTracker();
+    }
+
+    /// <summary>
+    /// Deletes all data from the EF database table for the Test Entity.
+    /// </summary>
+    public async Task ClearTestEntityTableAsync() => await ClearTableAsync<TestEntity>();
+
+    /// <summary>
+    /// Seeds data and returns an instance of EfRepository.
+    /// </summary>
+    /// <returns>An <see cref="EfRepository"/>.</returns>
+    public EfRepository GetEfRepository()
+    {
+        if (!_context.TestEntities.Any())
+        {
+            _context.TestEntities.AddRange(
+                new List<TestEntity>
+                {
+                    new() { Id = Guid.NewGuid(), Name = "Abc" },
+                    new() { Id = Guid.NewGuid(), Name = "Def" },
+                });
+            _context.SaveChanges();
+        }
+
+        Context = new AppDbContext(_options);
+        return new EfRepository(Context);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        Context.Dispose();
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Count.cs
+++ b/tests/Repositories/EfRepositoryTests/Count.cs
@@ -1,0 +1,59 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Count
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task CountAsync_WithoutPredicate_ReturnsCorrectCount()
+    {
+        var result = await _repository.CountAsync(e => true);
+
+        result.Should().Be(_repository.Context.Set<TestEntity>().Count());
+    }
+
+    [Test]
+    public async Task CountAsync_WithoutPredicate_WhenNoItemsExist_ReturnsZero()
+    {
+        await _helper.ClearTestEntityTableAsync();
+
+        var result = await _repository.CountAsync(e => true);
+
+        result.Should().Be(0);
+    }
+
+    [Test]
+    public async Task CountAsync_WithPredicate_ReturnsCorrectCount()
+    {
+        // Assuming this is the count you are expecting from your predicate.
+        var selectedItemsCount = _repository.Context.Set<TestEntity>().Count() - 1;
+
+        var result = await _repository.CountAsync(e => e.Id != _repository.Context.Set<TestEntity>().First().Id);
+
+        result.Should().Be(selectedItemsCount);
+    }
+
+    [Test]
+    public async Task CountAsync_WithPredicateThatDoesNotMatchAnyEntity_ReturnsZero()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.CountAsync(e => e.Id == id);
+
+        result.Should().Be(0);
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Delete.cs
+++ b/tests/Repositories/EfRepositoryTests/Delete.cs
@@ -1,0 +1,42 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Delete
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task DeleteAsync_DeleteExistingItem_ShouldDecreaseCountByOne()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        var initialCount = items.Count();
+        var entity = items.First();
+
+        await _repository.DeleteAsync(entity);
+
+        _repository.Context.Set<TestEntity>().Count().Should().Be(initialCount - 1);
+    }
+
+    [Test]
+    public async Task DeleteAsync_DeleteExistingItem_ItemShouldNoLongerExist()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        await _repository.DeleteAsync(entity);
+
+        (await _repository.FindAsync(entity.Id)).Should().BeNull();
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Exists.cs
+++ b/tests/Repositories/EfRepositoryTests/Exists.cs
@@ -1,0 +1,60 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Exists
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task ExistsAsync_WhenEntityExists_ReturnsTrue()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        var result = await _repository.ExistsAsync(entity.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenEntityDoesNotExist_ReturnsFalse()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.ExistsAsync(id);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ExistsAsync_UsingPredicate_WhenEntityExists_ReturnsTrue()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        var result = await _repository.ExistsAsync(e => e.Id == entity.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_UsingPredicate_WhenEntityDoesNotExist_ReturnsFall()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.ExistsAsync(e => e.Id == id);
+
+        result.Should().BeFalse();
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Find.cs
+++ b/tests/Repositories/EfRepositoryTests/Find.cs
@@ -1,0 +1,102 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Find
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task FindAsync_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        var result = await _repository.FindAsync(entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+
+    [Test]
+    public async Task FindAsync_WhenEntityDoesNotExist_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.FindAsync(id);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        var result = await _repository.FindAsync(e => e.Id == entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenEntityDoesNotExist_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.FindAsync(e => e.Id == id);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenUsingSqlite_IsCaseSensitive()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        // Test using a predicate that compares uppercase names.
+        var resultSameCase = await _repository.FindAsync(e =>
+            e.Name.ToUpper().Equals(entity.Name.ToUpper()));
+
+        // Test using a predicate that compares an uppercase name to a lowercase name.
+        var resultDifferentCase = await _repository.FindAsync(e =>
+            e.Name.ToUpper().Equals(entity.Name.ToLower()));
+
+        using (new AssertionScope())
+        {
+            resultSameCase.Should().BeEquivalentTo(entity);
+            resultDifferentCase.Should().BeNull();
+        }
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenUsingSqlServer_IsNotCaseSensitive()
+    {
+        using var repositoryHelper = EfRepositoryTestHelper.CreateSqlServerRepositoryHelper(this);
+        using var repository = repositoryHelper.GetEfRepository();
+        var entity = repository.Context.Set<TestEntity>().First();
+
+        // Test using a predicate that compares uppercase names.
+        var resultSameCase = await repository.FindAsync(e =>
+            e.Name.ToUpper().Equals(entity.Name.ToUpper()));
+
+        // Test using a predicate that compares an uppercase name to a lowercase name.
+        var resultDifferentCase = await repository.FindAsync(e =>
+            e.Name.ToUpper().Equals(entity.Name.ToLower()));
+
+        using (new AssertionScope())
+        {
+            resultSameCase.Should().BeEquivalentTo(entity);
+            resultDifferentCase.Should().BeEquivalentTo(entity);
+        }
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Get.cs
+++ b/tests/Repositories/EfRepositoryTests/Get.cs
@@ -1,0 +1,42 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Get
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetAsync_WhenEntityDoesNotExist_ThrowsException()
+    {
+        var id = Guid.NewGuid();
+
+        var func = async () => await _repository.GetAsync(id);
+
+        (await func.Should().ThrowAsync<EntityNotFoundException>())
+            .WithMessage($"Entity not found. Entity type: {typeof(TestEntity).FullName}, id: {id}");
+    }
+
+    [Test]
+    public async Task GetAsync_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Context.Set<TestEntity>().First();
+
+        var result = await _repository.GetAsync(entity.Id);
+
+        result.Should().Be(entity);
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/GetList.cs
+++ b/tests/Repositories/EfRepositoryTests/GetList.cs
@@ -1,0 +1,62 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class GetList
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetListAsync_ReturnsAllEntities()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+
+        var result = await _repository.GetListAsync();
+
+        result.Should().BeEquivalentTo(items);
+    }
+
+    [Test]
+    public async Task WhenNoItemsExist_ReturnsEmptyList()
+    {
+        await _helper.ClearTestEntityTableAsync();
+
+        var result = await _repository.GetListAsync();
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetListAsync_UsingPredicate_ReturnsCorrectEntities()
+    {
+        // Assuming this predicate selects correct items.
+        var items = _repository.Context.Set<TestEntity>();
+        var selectedItems = items.Skip(1).ToList();
+
+        var result = await _repository.GetListAsync(e => e.Id == selectedItems[0].Id);
+
+        result.Should().BeEquivalentTo(selectedItems);
+    }
+
+    [Test]
+    public async Task GetListAsync_UsingPredicate_WhenNoItemsMatch_ReturnsEmptyList()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.GetListAsync(e => e.Id == id);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/GetPagedList.cs
+++ b/tests/Repositories/EfRepositoryTests/GetPagedList.cs
@@ -1,0 +1,94 @@
+﻿using GaEpd.AppLibrary.Pagination;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+using System.Globalization;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class GetPagedList
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetPagedListAsync_ReturnsCorrectPagedResults()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        var paging = new PaginatedRequest(2, 1);
+        var expectedResults = items.Skip(paging.Skip).Take(paging.Take).ToList();
+
+        var results = await _repository.GetPagedListAsync(paging);
+
+        results.Should().BeEquivalentTo(expectedResults);
+    }
+
+    [Test]
+    public async Task GetPagedListAsync_WithPredicate_ReturnsCorrectPagedResults()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        // Assuming this is the correct selection based on your predicate.
+        var selectedItems = items.Skip(1).ToList();
+        var paging = new PaginatedRequest(1, 1);
+        var expectedResults = selectedItems.Skip(paging.Skip).Take(paging.Take).ToList();
+
+        var results = await _repository.GetPagedListAsync(e => e.Id == selectedItems[0].Id, paging);
+
+        results.Should().BeEquivalentTo(expectedResults);
+    }
+
+    [Test]
+    public async Task WhenNoItemsExist_ReturnsEmptyList()
+    {
+        await _helper.ClearTestEntityTableAsync();
+        var paging = new PaginatedRequest(1, 1);
+
+        var result = await _repository.GetPagedListAsync(paging);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task WhenPagedBeyondExistingItems_ReturnsEmptyList()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        var paging = new PaginatedRequest(2, items.Count());
+
+        var result = await _repository.GetPagedListAsync(paging);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GivenSorting_ReturnsSortedList()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        var itemsCount = items.Count();
+        var pagingAsc = new PaginatedRequest(1, itemsCount, "Name asc");
+        var pagingDesc = new PaginatedRequest(1, itemsCount, "Name desc");
+
+        var resultAsc = await _repository.GetPagedListAsync(pagingAsc);
+        var resultDesc = await _repository.GetPagedListAsync(pagingDesc);
+
+        using (new AssertionScope())
+        {
+            resultAsc.Count.Should().Be(itemsCount);
+            resultDesc.Count.Should().Be(itemsCount);
+            resultAsc.Should().BeEquivalentTo(items);
+            resultDesc.Should().BeEquivalentTo(items);
+
+            var comparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
+            resultAsc.Should().BeInAscendingOrder(e => e.Name, comparer);
+            resultDesc.Should().BeInDescendingOrder(e => e.Name, comparer);
+        }
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Insert.cs
+++ b/tests/Repositories/EfRepositoryTests/Insert.cs
@@ -1,0 +1,43 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Insert
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task InsertAsync_AddNewItem_ShouldIncreaseCountByOne()
+    {
+        var items = _repository.Context.Set<TestEntity>();
+        var initialCount = items.Count();
+        var entity = new TestEntity { Id = Guid.NewGuid() };
+
+        await _repository.InsertAsync(entity);
+
+        items.Count().Should().Be(initialCount + 1);
+    }
+
+    [Test]
+    public async Task InsertAsync_AddNewItem_ShouldBeAbleToRetrieveNewItem()
+    {
+        var entity = new TestEntity { Id = Guid.NewGuid() };
+
+        await _repository.InsertAsync(entity);
+        var result = await _repository.GetAsync(entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+}

--- a/tests/Repositories/EfRepositoryTests/Update.cs
+++ b/tests/Repositories/EfRepositoryTests/Update.cs
@@ -1,0 +1,51 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.EfRepositoryTests;
+
+public class Update
+{
+    private EfRepositoryTestHelper _helper = default!;
+
+    private EfRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _helper = EfRepositoryTestHelper.CreateRepositoryHelper();
+        _repository = _helper.GetEfRepository();
+    }
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task UpdateAsync_UpdateExistingItem_ShouldReflectChanges()
+    {
+        var originalEntity = _repository.Context.Set<TestEntity>().First();
+        _helper.ClearChangeTracker();
+        var newEntityWithSameId = new TestEntity { Id = originalEntity.Id, Name = "Xyz" };
+
+        await _repository.UpdateAsync(newEntityWithSameId);
+
+        _helper.ClearChangeTracker();
+        var result = await _repository.GetAsync(newEntityWithSameId.Id);
+
+        using (new AssertionScope())
+        {
+            result.Should().BeEquivalentTo(newEntityWithSameId);
+            _repository.Context.Set<TestEntity>().ToList().Contains(originalEntity).Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public async Task UpdateAsync_WhenItemDoesNotExist_Throws()
+    {
+        var item = new TestEntity { Id = Guid.NewGuid() };
+
+        var action = async () => await _repository.UpdateAsync(item);
+
+        (await action.Should().ThrowAsync<EntityNotFoundException>())
+            .WithMessage($"Entity not found. Entity type: {typeof(TestEntity).FullName}, id: {item.Id}");
+    }
+}

--- a/tests/Repositories/LocalRepositoryTestHelper.cs
+++ b/tests/Repositories/LocalRepositoryTestHelper.cs
@@ -1,0 +1,18 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories.LocalRepository;
+
+namespace GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+public class LocalRepository : BaseRepository<TestEntity, Guid>
+{
+    public LocalRepository(IEnumerable<TestEntity> items) : base(items) { }
+}
+
+public static class LocalRepositoryTestHelper
+{
+    public static LocalRepository GetTestRepository() =>
+        new(new List<TestEntity>
+        {
+            new() { Id = Guid.NewGuid(), Name = "Abc" },
+            new() { Id = Guid.NewGuid(), Name = "Def" },
+        });
+}

--- a/tests/Repositories/LocalRepositoryTests/Count.cs
+++ b/tests/Repositories/LocalRepositoryTests/Count.cs
@@ -1,0 +1,51 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Count
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task CountAsync_WithoutPredicate_ReturnsCorrectCount()
+    {
+        var result = await _repository.CountAsync(e => true);
+
+        result.Should().Be(_repository.Items.Count);
+    }
+
+    [Test]
+    public async Task CountAsync_WithoutPredicate_WhenNoItemsExist_ReturnsZero()
+    {
+        _repository.Items.Clear();
+
+        var result = await _repository.CountAsync(e => true);
+
+        result.Should().Be(0);
+    }
+
+    [Test]
+    public async Task CountAsync_WithPredicate_ReturnsCorrectCount()
+    {
+        // Assuming this is the count you are expecting from your predicate.
+        var selectedItemsCount = _repository.Items.Count - 1;
+
+        var result = await _repository.CountAsync(e => e.Id != _repository.Items.First().Id);
+
+        result.Should().Be(selectedItemsCount);
+    }
+
+    [Test]
+    public async Task CountAsync_WithPredicateThatDoesNotMatchAnyEntity_ReturnsZero()
+    {
+        var result = await _repository.CountAsync(e => e.Id == Guid.NewGuid());
+
+        result.Should().Be(0);
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Delete.cs
+++ b/tests/Repositories/LocalRepositoryTests/Delete.cs
@@ -1,0 +1,35 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Delete
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task DeleteAsync_DeleteExistingItem_ShouldDecreaseCountByOne()
+    {
+        var initialCount = _repository.Items.Count;
+        var entity = _repository.Items.First();
+
+        await _repository.DeleteAsync(entity);
+
+        _repository.Items.Count.Should().Be(initialCount - 1);
+    }
+
+    [Test]
+    public async Task DeleteAsync_DeleteExistingItem_ItemShouldNoLongerExist()
+    {
+        var entity = _repository.Items.First();
+
+        await _repository.DeleteAsync(entity);
+
+        (await _repository.FindAsync(entity.Id)).Should().BeNull();
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Exists.cs
+++ b/tests/Repositories/LocalRepositoryTests/Exists.cs
@@ -1,0 +1,52 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Exists
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task ExistsAsync_WhenEntityExists_ReturnsTrue()
+    {
+        var entity = _repository.Items.First();
+
+        var result = await _repository.ExistsAsync(entity.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_WhenEntityDoesNotExist_ReturnsFalse()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.ExistsAsync(id);
+
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ExistsAsync_UsingPredicate_WhenEntityExists_ReturnsTrue()
+    {
+        var entity = _repository.Items.First();
+
+        var result = await _repository.ExistsAsync(e => e.Id == entity.Id);
+
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ExistsAsync_UsingPredicate_WhenEntityDoesNotExist_ReturnsFall()
+    {
+        var result = await _repository.ExistsAsync(e => e.Id == Guid.NewGuid());
+
+        result.Should().BeFalse();
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Find.cs
+++ b/tests/Repositories/LocalRepositoryTests/Find.cs
@@ -1,0 +1,70 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Find
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task FindAsync_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Items.First();
+
+        var result = await _repository.FindAsync(entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+
+    [Test]
+    public async Task FindAsync_WhenEntityDoesNotExist_ReturnsNull()
+    {
+        var id = Guid.NewGuid();
+
+        var result = await _repository.FindAsync(id);
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Items.First();
+
+        var result = await _repository.FindAsync(e => e.Id == entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenEntityDoesNotExist_ReturnsNull()
+    {
+        var result = await _repository.FindAsync(e => e.Id == Guid.NewGuid());
+
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public async Task FindAsync_UsingPredicate_WhenUsingLocalRepository_IsCaseSensitive()
+    {
+        var entity = _repository.Items.First();
+
+        var resultIgnoreCase = await _repository.FindAsync(e =>
+            e.Name.ToUpperInvariant().Equals(entity.Name.ToLowerInvariant(), StringComparison.CurrentCultureIgnoreCase));
+
+        var resultCaseSensitive = await _repository.FindAsync(e =>
+            e.Name.ToUpperInvariant().Equals(entity.Name.ToLowerInvariant(), StringComparison.CurrentCulture));
+
+        using (new AssertionScope())
+        {
+            resultIgnoreCase.Should().BeEquivalentTo(entity);
+            resultCaseSensitive.Should().BeNull();
+        }
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Get.cs
+++ b/tests/Repositories/LocalRepositoryTests/Get.cs
@@ -1,0 +1,36 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Get
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetAsync_WhenEntityDoesNotExist_ThrowsException()
+    {
+        var id = Guid.NewGuid();
+
+        var func = async () => await _repository.GetAsync(id);
+
+        (await func.Should().ThrowAsync<EntityNotFoundException>())
+            .WithMessage($"Entity not found. Entity type: {typeof(TestEntity).FullName}, id: {id}");
+    }
+
+    [Test]
+    public async Task GetAsync_WhenEntityExists_ReturnsEntity()
+    {
+        var entity = _repository.Items.First();
+
+        var result = await _repository.GetAsync(entity.Id);
+
+        result.Should().Be(entity);
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/GetList.cs
+++ b/tests/Repositories/LocalRepositoryTests/GetList.cs
@@ -1,0 +1,51 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class GetList
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetListAsync_ReturnsAllEntities()
+    {
+        var result = await _repository.GetListAsync();
+
+        result.Should().BeEquivalentTo(_repository.Items);
+    }
+
+    [Test]
+    public async Task WhenNoItemsExist_ReturnsEmptyList()
+    {
+        _repository.Items.Clear();
+
+        var result = await _repository.GetListAsync();
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GetListAsync_UsingPredicate_ReturnsCorrectEntities()
+    {
+        // Assuming this predicate selects correct items.
+        var selectedItems = _repository.Items.Skip(1).ToList();
+
+        var result = await _repository.GetListAsync(e => e.Id == selectedItems[0].Id);
+
+        result.Should().BeEquivalentTo(selectedItems);
+    }
+
+    [Test]
+    public async Task GetListAsync_UsingPredicate_WhenNoItemsMatch_ReturnsEmptyList()
+    {
+        var result = await _repository.GetListAsync(e => e.Id == Guid.NewGuid());
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/GetPagedList.cs
+++ b/tests/Repositories/LocalRepositoryTests/GetPagedList.cs
@@ -1,0 +1,84 @@
+﻿using GaEpd.AppLibrary.Pagination;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+using System.Globalization;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class GetPagedList
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task GetPagedListAsync_ReturnsCorrectPagedResults()
+    {
+        var paging = new PaginatedRequest(2, 1);
+        var expectedResults = _repository.Items.Skip(paging.Skip).Take(paging.Take).ToList();
+
+        var results = await _repository.GetPagedListAsync(paging);
+
+        results.Should().BeEquivalentTo(expectedResults);
+    }
+
+    [Test]
+    public async Task GetPagedListAsync_WithPredicate_ReturnsCorrectPagedResults()
+    {
+        // Assuming this is the correct selection based on your predicate.
+        var selectedItems = _repository.Items.Skip(1).ToList();
+        var paging = new PaginatedRequest(1, 1);
+        var expectedResults = selectedItems.Skip(paging.Skip).Take(paging.Take).ToList();
+
+        var results = await _repository.GetPagedListAsync(e => e.Id == selectedItems[0].Id, paging);
+
+        results.Should().BeEquivalentTo(expectedResults);
+    }
+
+    [Test]
+    public async Task WhenNoItemsExist_ReturnsEmptyList()
+    {
+        _repository.Items.Clear();
+        var paging = new PaginatedRequest(1, 1);
+
+        var result = await _repository.GetPagedListAsync(paging);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task WhenPagedBeyondExistingItems_ReturnsEmptyList()
+    {
+        var paging = new PaginatedRequest(2, _repository.Items.Count);
+
+        var result = await _repository.GetPagedListAsync(paging);
+
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task GivenSorting_ReturnsSortedList()
+    {
+        var itemsCount = _repository.Items.Count;
+        var pagingAsc = new PaginatedRequest(1, itemsCount, "Name asc");
+        var pagingDesc = new PaginatedRequest(1, itemsCount, "Name desc");
+
+        var resultAsc = await _repository.GetPagedListAsync(pagingAsc);
+        var resultDesc = await _repository.GetPagedListAsync(pagingDesc);
+
+        using (new AssertionScope())
+        {
+            resultAsc.Count.Should().Be(itemsCount);
+            resultDesc.Count.Should().Be(itemsCount);
+            resultAsc.Should().BeEquivalentTo(_repository.Items);
+            resultDesc.Should().BeEquivalentTo(_repository.Items);
+
+            var comparer = CultureInfo.InvariantCulture.CompareInfo.GetStringComparer(CompareOptions.IgnoreCase);
+            resultAsc.Should().BeInAscendingOrder(e => e.Name, comparer);
+            resultDesc.Should().BeInDescendingOrder(e => e.Name, comparer);
+        }
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Insert.cs
+++ b/tests/Repositories/LocalRepositoryTests/Insert.cs
@@ -1,0 +1,36 @@
+﻿using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Insert
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task InsertAsync_AddNewItem_ShouldIncreaseCountByOne()
+    {
+        var initialCount = _repository.Items.Count;
+        var entity = new TestEntity { Id = Guid.NewGuid() };
+
+        await _repository.InsertAsync(entity);
+
+        _repository.Items.Count.Should().Be(initialCount + 1);
+    }
+
+    [Test]
+    public async Task InsertAsync_AddNewItem_ShouldBeAbleToRetrieveNewItem()
+    {
+        var entity = new TestEntity { Id = Guid.NewGuid() };
+
+        await _repository.InsertAsync(entity);
+        var result = await _repository.GetAsync(entity.Id);
+
+        result.Should().BeEquivalentTo(entity);
+    }
+}

--- a/tests/Repositories/LocalRepositoryTests/Update.cs
+++ b/tests/Repositories/LocalRepositoryTests/Update.cs
@@ -1,0 +1,43 @@
+﻿using GaEpd.AppLibrary.Domain.Repositories;
+using GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+namespace GaEpd.AppLibrary.Tests.LocalRepositoryTests;
+
+public class Update
+{
+    private LocalRepository _repository = default!;
+
+    [SetUp]
+    public void SetUp() => _repository = LocalRepositoryTestHelper.GetTestRepository();
+
+    [TearDown]
+    public void TearDown() => _repository.Dispose();
+
+    [Test]
+    public async Task UpdateAsync_UpdateExistingItem_ShouldReflectChanges()
+    {
+        var originalEntity = _repository.Items.First();
+        var newEntityWithSameId = new TestEntity { Id = originalEntity.Id, Name = "Xyz" };
+
+        await _repository.UpdateAsync(newEntityWithSameId);
+
+        var result = await _repository.GetAsync(newEntityWithSameId.Id);
+
+        using (new AssertionScope())
+        {
+            result.Should().BeEquivalentTo(newEntityWithSameId);
+            _repository.Items.Contains(originalEntity).Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public async Task UpdateAsync_WhenItemDoesNotExist_Throws()
+    {
+        var item = new TestEntity { Id = Guid.NewGuid() };
+
+        var action = async () => await _repository.UpdateAsync(item);
+
+        (await action.Should().ThrowAsync<EntityNotFoundException>())
+            .WithMessage($"Entity not found. Entity type: {typeof(TestEntity).FullName}, id: {item.Id}");
+    }
+}

--- a/tests/Repositories/TestEntity.cs
+++ b/tests/Repositories/TestEntity.cs
@@ -1,0 +1,9 @@
+﻿using GaEpd.AppLibrary.Domain.Entities;
+
+namespace GaEpd.AppLibrary.Tests.RepositoryHelpers;
+
+public class TestEntity : IEntity<Guid>
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+}

--- a/tests/ValueObjectTests/EqualityTests.cs
+++ b/tests/ValueObjectTests/EqualityTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using GaEpd.AppLibrary.Domain.ValueObjects;
+﻿using GaEpd.AppLibrary.Domain.ValueObjects;
 
 namespace GaEpd.AppLibrary.Tests.ValueObjectTests;
 

--- a/tests/appsettings.json
+++ b/tests/appsettings.json
@@ -1,0 +1,5 @@
+﻿{
+  "ConnectionStrings": {
+    "UnitTestConnection": "Server=(localdb)\\mssqllocaldb;Database=app-Test;Trusted_Connection=True;MultipleActiveResultSets=true"
+  }
+}


### PR DESCRIPTION
This PR adds two abstract `BaseRepository` classes that each implement the `IRepository` interface, one using in-memory data and the other requiring an Entity Framework database context.