### PR TITLE
Enable change tracking for the new Get method with include properties

### DIFF
--- a/src/AppLibrary/Domain/Repositories/EFRepository/BaseRepository.cs
+++ b/src/AppLibrary/Domain/Repositories/EFRepository/BaseRepository.cs
@@ -37,7 +37,7 @@ public abstract class BaseRepository<TEntity, TKey, TContext>(TContext context)
         ?? throw new EntityNotFoundException<TEntity>(id);
 
     public async Task<TEntity> GetAsync(TKey id, string[] includeProperties, CancellationToken token = default) =>
-        await includeProperties.Aggregate(Context.Set<TEntity>().AsNoTracking(),
+        await includeProperties.Aggregate(Context.Set<TEntity>().AsQueryable(),
                 (queryable, includeProperty) => queryable.Include(includeProperty))
             .SingleOrDefaultAsync(entity => entity.Id.Equals(id), token).ConfigureAwait(false)
         ?? throw new EntityNotFoundException<TEntity>(id);


### PR DESCRIPTION
The new `GetAsync` method added in #45 incorrectly [included `.AsNoTracking()`](https://github.com/gaepdit/app-library/commit/ca3b1ad8eef23653243bf6c78b11400a1dff2e04#diff-a9d14c0a4ada95b8c5756feae2a826e8299f384eb4bcd26166737922ef62078cR40). Since this method is used when updating entities, change tracking should be enabled.