### PR TITLE
Add overloads to the `IReadRepository` interface and implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- **Unbreaking change:** Increased the number of overloads in the `IReadRepository` interface by using fewer optional
+  parameters. (This avoids requiring calls to the read repository methods to be rewritten if updating from a pre-6.0
+  version.)
+
 ## [6.0.0] - 2025-03-31
 
 - **Breaking:** Reduced the number of overloads in the `IReadRepository` interface by using more optional parameters.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,25 +3,24 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="8.1.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="EfCore.TestSupport" Version="9.0.0" />
     <PackageVersion Include="GaEpd.GuardClauses" Version="2.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.7.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.8.0.113526" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.15" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
   </ItemGroup>
 </Project>

--- a/src/AppLibrary/AppLibrary.csproj
+++ b/src/AppLibrary/AppLibrary.csproj
@@ -43,10 +43,6 @@
     <ItemGroup>
         <PackageReference Include="GaEpd.GuardClauses" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="SonarAnalyzer.CSharp">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/AppLibrary/Domain/Repositories/EFRepository/NamedEntityRepository.cs
+++ b/src/AppLibrary/Domain/Repositories/EFRepository/NamedEntityRepository.cs
@@ -15,9 +15,10 @@ public abstract class NamedEntityRepository<TEntity, TContext>(TContext context)
     where TEntity : class, IEntity, INamedEntity
     where TContext : DbContext
 {
-    public Task<TEntity?> FindByNameAsync(string name, CancellationToken token = default) =>
-        Context.Set<TEntity>().AsNoTracking()
-            .SingleOrDefaultAsync(entity => string.Equals(entity.Name.ToUpper(), name.ToUpper()), token);
+    public async Task<TEntity?> FindByNameAsync(string name, CancellationToken token = default) =>
+        await Context.Set<TEntity>().AsNoTracking()
+            .SingleOrDefaultAsync(entity => string.Equals(entity.Name.ToUpper(), name.ToUpper()), token)
+            .ConfigureAwait(false);
 
     public async Task<IReadOnlyCollection<TEntity>> GetOrderedListAsync(CancellationToken token = default) =>
         await Context.Set<TEntity>().AsNoTracking()

--- a/src/AppLibrary/Domain/Repositories/IReadRepository.cs
+++ b/src/AppLibrary/Domain/Repositories/IReadRepository.cs
@@ -17,44 +17,99 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable, IAsyncDisposab
     /// Returns the <see cref="TEntity"/> with the given <paramref name="id"/>.
     /// </summary>
     /// <param name="id">The ID of the entity.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <exception cref="EntityNotFoundException{TEntity}">Thrown if no entity exists with the given ID.</exception>
     /// <returns>An entity.</returns>
-    Task<TEntity> GetAsync(TKey id, string[]? includeProperties = null, CancellationToken token = default);
+    Task<TEntity> GetAsync(TKey id, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns the <see cref="TEntity"/> with the given <paramref name="id"/>.
+    /// </summary>
+    /// <param name="id">The ID of the entity.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <exception cref="EntityNotFoundException{TEntity}">Thrown if no entity exists with the given ID.</exception>
+    /// <returns>An entity.</returns>
+    Task<TEntity> GetAsync(TKey id, string[] includeProperties, CancellationToken token = default);
 
     /// <summary>
     /// Returns the <see cref="TEntity"/> matching the given <paramref name="id"/>.
     /// Returns null if there are no matches.
     /// </summary>
     /// <param name="id">The ID of the entity.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <exception cref="InvalidOperationException">Thrown if there are multiple matches.</exception>
     /// <returns>An entity or null.</returns>
-    Task<TEntity?> FindAsync(TKey id, string[]? includeProperties = null, CancellationToken token = default);
+    Task<TEntity?> FindAsync(TKey id, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns the <see cref="TEntity"/> matching the given <paramref name="id"/>.
+    /// Returns null if there are no matches.
+    /// </summary>
+    /// <param name="id">The ID of the entity.</param>
+    /// <param name="includeProperties">navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <exception cref="InvalidOperationException">Thrown if there are multiple matches.</exception>
+    /// <returns>An entity or null.</returns>
+    Task<TEntity?> FindAsync(TKey id, string[] includeProperties, CancellationToken token = default);
 
     /// <summary>
     /// Returns a single <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.
     /// Returns null if there are no matches.
     /// </summary>
     /// <param name="predicate">The search conditions.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <exception cref="InvalidOperationException">Thrown if there are multiple matches.</exception>
     /// <returns>An entity or null.</returns>
-    Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, string[]? includeProperties = null,
+    Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a single <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.
+    /// Returns null if there are no matches.
+    /// </summary>
+    /// <param name="predicate">The search conditions.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <exception cref="InvalidOperationException">Thrown if there are multiple matches.</exception>
+    /// <returns>An entity or null.</returns>
+    Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, string[] includeProperties,
         CancellationToken token = default);
 
     /// <summary>
     /// Returns a read-only collection of all <see cref="IEntity{TKey}"/> values.
-    /// Returns an empty collection if none exist.
+    /// Returns an empty collection if there are no matches.
     /// </summary>
-    /// <param name="ordering">An optional expression string to indicate values to order by.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A read-only collection of entities.</returns>
-    Task<IReadOnlyCollection<TEntity>> GetListAsync(string? ordering = null, string[]? includeProperties = null,
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of all <see cref="IEntity{TKey}"/> values.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="ordering">An expression string to indicate values to order by.</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(string ordering, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of all <see cref="IEntity{TKey}"/> values.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(string[] includeProperties, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of all <see cref="IEntity{TKey}"/> values.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="ordering">An expression string to indicate values to order by.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(string ordering, string[] includeProperties,
         CancellationToken token = default);
 
     /// <summary>
@@ -62,12 +117,44 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable, IAsyncDisposab
     /// Returns an empty collection if there are no matches.
     /// </summary>
     /// <param name="predicate">The search conditions.</param>
-    /// <param name="ordering">An optional expression string to indicate values to order by.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A read-only collection of entities.</returns>
-    Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate, string? ordering = null,
-        string[]? includeProperties = null, CancellationToken token = default);
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate,
+        CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="predicate">The search conditions.</param>
+    /// <param name="ordering">An expression string to indicate values to order by.</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate, string ordering,
+        CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="predicate">The search conditions.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate,
+        string[] includeProperties, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a read-only collection of <see cref="IEntity{TKey}"/> matching the conditions of the <paramref name="predicate"/>.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="predicate">The search conditions.</param>
+    /// <param name="ordering">An expression string to indicate values to order by.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate, string ordering,
+        string[] includeProperties, CancellationToken token = default);
 
     /// <summary>
     /// Returns a filtered, read-only collection of <see cref="IEntity{TKey}"/> matching the conditions of the
@@ -75,21 +162,41 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable, IAsyncDisposab
     /// </summary>
     /// <param name="predicate">The search conditions.</param>
     /// <param name="paging">A <see cref="PaginatedRequest"/> to define the paging options.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A sorted and paged read-only collection of entities.</returns>
     Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(Expression<Func<TEntity, bool>> predicate,
-        PaginatedRequest paging, string[]? includeProperties = null, CancellationToken token = default);
+        PaginatedRequest paging, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a filtered, read-only collection of <see cref="IEntity{TKey}"/> matching the conditions of the
+    /// <paramref name="predicate"/>. Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="predicate">The search conditions.</param>
+    /// <param name="paging">A <see cref="PaginatedRequest"/> to define the paging options.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A sorted and paged read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(Expression<Func<TEntity, bool>> predicate,
+        PaginatedRequest paging, string[] includeProperties, CancellationToken token = default);
 
     /// <summary>
     /// Returns a filtered, read-only collection of all <see cref="IEntity{TKey}"/> values.
     /// Returns an empty collection if there are no matches.
     /// </summary>
     /// <param name="paging">A <see cref="PaginatedRequest"/> to define the paging options.</param>
-    /// <param name="includeProperties">Optional navigation properties to include (when using an Entity Framework repository).</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
     /// <returns>A sorted and paged read-only collection of entities.</returns>
-    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging, string[]? includeProperties = null,
+    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging, CancellationToken token = default);
+
+    /// <summary>
+    /// Returns a filtered, read-only collection of all <see cref="IEntity{TKey}"/> values.
+    /// Returns an empty collection if there are no matches.
+    /// </summary>
+    /// <param name="paging">A <see cref="PaginatedRequest"/> to define the paging options.</param>
+    /// <param name="includeProperties">Navigation properties to include (when using an Entity Framework repository).</param>
+    /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
+    /// <returns>A sorted and paged read-only collection of entities.</returns>
+    Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging, string[] includeProperties,
         CancellationToken token = default);
 
     /// <summary>
@@ -106,7 +213,7 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable, IAsyncDisposab
     /// </summary>
     /// <param name="id">The ID of the entity.</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
-    /// <returns>True if the entity exists; otherwise false.</returns>
+    /// <returns>True if the entity exists. Otherwise, false.</returns>
     public Task<bool> ExistsAsync(TKey id, CancellationToken token = default);
 
     /// <summary>
@@ -115,6 +222,6 @@ public interface IReadRepository<TEntity, in TKey> : IDisposable, IAsyncDisposab
     /// </summary>
     /// <param name="predicate">The search conditions.</param>
     /// <param name="token"><see cref="T:System.Threading.CancellationToken"/></param>
-    /// <returns>True if the entity exists; otherwise false.</returns>
+    /// <returns>True if the entity exists. Otherwise, false.</returns>
     public Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default);
 }

--- a/src/AppLibrary/Domain/Repositories/LocalRepository/BaseRepository.cs
+++ b/src/AppLibrary/Domain/Repositories/LocalRepository/BaseRepository.cs
@@ -18,7 +18,7 @@ public abstract class BaseRepository<TEntity>(IEnumerable<TEntity> items)
 /// </summary>
 /// <typeparam name="TEntity">The entity type.</typeparam>
 /// <typeparam name="TKey">The primary key type for the entity.</typeparam>
-/// <remarks>Navigation properties are already included when using in-memory data structures
+/// <remarks>Navigation properties are already included when using in-memory data structures,
 /// so any `includeProperties` parameters are ignored.</remarks>
 public abstract class BaseRepository<TEntity, TKey>(IEnumerable<TEntity> items)
     : IRepository<TEntity, TKey>
@@ -27,49 +27,117 @@ public abstract class BaseRepository<TEntity, TKey>(IEnumerable<TEntity> items)
 {
     public ICollection<TEntity> Items { get; } = items.ToList();
 
-    // Navigation properties are already included when using in-memory data structures.
-    public async Task<TEntity> GetAsync(TKey id, string[]? includeProperties = null,
-        CancellationToken token = default) =>
-        await FindAsync(id, includeProperties, token).ConfigureAwait(false) ??
+    // Navigation properties are already included when using in-memory data structures so are not used in the internal methods.
+
+    // GetAsync
+    public Task<TEntity> GetAsync(TKey id, CancellationToken token = default) =>
+        GetAsyncInternal(id);
+
+    public Task<TEntity> GetAsync(TKey id, string[] includeProperties, CancellationToken token = default) =>
+        GetAsyncInternal(id);
+
+    private async Task<TEntity> GetAsyncInternal(TKey id) =>
+        await FindAsyncInternal(id).ConfigureAwait(false) ??
         throw new EntityNotFoundException<TEntity>(id);
 
-    // Navigation properties are already included when using in-memory data structures.
-    public Task<TEntity?> FindAsync(TKey id, string[]? includeProperties = null, CancellationToken token = default) =>
-        Task.FromResult(Items.SingleOrDefault(entity => entity.Id.Equals(id)));
+    // FindAsync
+    public Task<TEntity?> FindAsync(TKey id, CancellationToken token = default) =>
+        FindAsyncInternal(id);
 
-    public Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, string[]? includeProperties = null,
-        CancellationToken token = default) =>
-        Task.FromResult(Items.SingleOrDefault(predicate.Compile()));
+    public Task<TEntity?> FindAsync(TKey id, string[] includeProperties, CancellationToken token = default) =>
+        FindAsyncInternal(id);
 
-    // Navigation properties are already included when using in-memory data structures.
-    public Task<IReadOnlyCollection<TEntity>> GetListAsync(string? ordering = null, string[]? includeProperties = null,
+    public Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        FindAsyncInternal(predicate);
+
+    public Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>> predicate, string[] includeProperties,
         CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(Items.AsQueryable().OrderByIf(ordering).ToList());
+        FindAsyncInternal(predicate);
+
+    private Task<TEntity?> FindAsyncInternal(TKey id) =>
+        FindAsyncInternal(entity => entity.Id.Equals(id));
+
+    private async Task<TEntity?> FindAsyncInternal(Expression<Func<TEntity, bool>> predicate) =>
+        await Task.FromResult(Items.SingleOrDefault(predicate.Compile())).ConfigureAwait(false);
+
+    // GetListAsync
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(CancellationToken token = default) =>
+        GetListAsyncInternal();
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(string ordering, CancellationToken token = default) =>
+        GetListAsyncInternal(ordering);
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(string[] includeProperties,
+        CancellationToken token = default) =>
+        GetListAsyncInternal();
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(string ordering, string[] includeProperties,
+        CancellationToken token = default) =>
+        GetListAsyncInternal(ordering);
 
     public Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate,
-        string? ordering = null, string[]? includeProperties = null, CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(Items.Where(predicate.Compile()).AsQueryable().OrderByIf(ordering)
-            .ToList());
+        CancellationToken token = default) =>
+        GetListAsyncInternal(predicate);
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate,
+        string ordering, CancellationToken token = default) =>
+        GetListAsyncInternal(predicate, ordering);
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate,
+        string[] includeProperties, CancellationToken token = default) =>
+        GetListAsyncInternal(predicate);
+
+    public Task<IReadOnlyCollection<TEntity>> GetListAsync(Expression<Func<TEntity, bool>> predicate, string ordering,
+        string[] includeProperties, CancellationToken token = default) =>
+        GetListAsyncInternal(predicate, ordering);
+
+    private async Task<IReadOnlyCollection<TEntity>> GetListAsyncInternal(string? ordering = null) =>
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.AsQueryable().OrderByIf(ordering).ToList())
+            .ConfigureAwait(false);
+
+    private async Task<IReadOnlyCollection<TEntity>> GetListAsyncInternal(Expression<Func<TEntity, bool>> predicate,
+        string? ordering = null) =>
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.Where(predicate.Compile()).AsQueryable()
+            .OrderByIf(ordering).ToList()).ConfigureAwait(false);
+
+    // GetPagedListAsync
+    public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(Expression<Func<TEntity, bool>> predicate,
+        PaginatedRequest paging, CancellationToken token = default) =>
+        GetPagedListAsyncInternal(predicate, paging);
 
     public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(Expression<Func<TEntity, bool>> predicate,
-        PaginatedRequest paging, string[]? includeProperties = null, CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(Items.Where(predicate.Compile()).AsQueryable()
-            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToList());
+        PaginatedRequest paging, string[] includeProperties, CancellationToken token = default) =>
+        GetPagedListAsyncInternal(predicate, paging);
 
     public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging,
-        string[]? includeProperties = null, CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(Items.AsQueryable()
-            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToList());
+        CancellationToken token = default) =>
+        GetPagedListAsyncInternal(paging);
 
-    public Task<int> CountAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
-        Task.FromResult(Items.Count(predicate.Compile()));
+    public Task<IReadOnlyCollection<TEntity>> GetPagedListAsync(PaginatedRequest paging,
+        string[] includeProperties, CancellationToken token = default) =>
+        GetPagedListAsyncInternal(paging);
 
+    private async Task<IReadOnlyCollection<TEntity>> GetPagedListAsyncInternal(
+        Expression<Func<TEntity, bool>> predicate, PaginatedRequest paging) =>
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.Where(predicate.Compile()).AsQueryable()
+            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToList()).ConfigureAwait(false);
+
+    private async Task<IReadOnlyCollection<TEntity>> GetPagedListAsyncInternal(PaginatedRequest paging) =>
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.AsQueryable()
+            .OrderByIf(paging.Sorting).Skip(paging.Skip).Take(paging.Take).ToList()).ConfigureAwait(false);
+
+    // CountAsync
+    public async Task<int> CountAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        await Task.FromResult(Items.Count(predicate.Compile())).ConfigureAwait(false);
+
+    // ExistsAsync
     public Task<bool> ExistsAsync(TKey id, CancellationToken token = default) =>
-        Task.FromResult(Items.Any(entity => entity.Id.Equals(id)));
+        ExistsAsync(entity => entity.Id.Equals(id), token);
 
-    public Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
-        Task.FromResult(Items.Any(predicate.Compile()));
+    public async Task<bool> ExistsAsync(Expression<Func<TEntity, bool>> predicate, CancellationToken token = default) =>
+        await Task.FromResult(Items.Any(predicate.Compile())).ConfigureAwait(false);
 
+    // IWriteRepository methods
     public Task InsertAsync(TEntity entity, bool autoSave = true, CancellationToken token = default)
     {
         Items.Add(entity);

--- a/src/AppLibrary/Domain/Repositories/LocalRepository/NamedEntityRepository.cs
+++ b/src/AppLibrary/Domain/Repositories/LocalRepository/NamedEntityRepository.cs
@@ -12,15 +12,16 @@ public abstract class NamedEntityRepository<TEntity>(IEnumerable<TEntity> items)
     : BaseRepository<TEntity>(items), INamedEntityRepository<TEntity>
     where TEntity : class, IEntity, INamedEntity
 {
-    public Task<TEntity?> FindByNameAsync(string name, CancellationToken token = default) =>
-        Task.FromResult(Items.SingleOrDefault(entity => string.Equals(entity.Name.ToUpper(), name.ToUpper())));
+    public async Task<TEntity?> FindByNameAsync(string name, CancellationToken token = default) =>
+        await Task.FromResult(Items.SingleOrDefault(entity => string.Equals(entity.Name.ToUpper(), name.ToUpper())))
+            .ConfigureAwait(false);
 
-    public Task<IReadOnlyCollection<TEntity>> GetOrderedListAsync(CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(
-            Items.OrderBy(entity => entity.Name).ThenBy(entity => entity.Id).ToList());
+    public async Task<IReadOnlyCollection<TEntity>> GetOrderedListAsync(CancellationToken token = default) =>
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.OrderBy(entity => entity.Name)
+            .ThenBy(entity => entity.Id).ToList()).ConfigureAwait(false);
 
-    public Task<IReadOnlyCollection<TEntity>> GetOrderedListAsync(Expression<Func<TEntity, bool>> predicate,
+    public async Task<IReadOnlyCollection<TEntity>> GetOrderedListAsync(Expression<Func<TEntity, bool>> predicate,
         CancellationToken token = default) =>
-        Task.FromResult<IReadOnlyCollection<TEntity>>(
-            Items.Where(predicate.Compile()).OrderBy(entity => entity.Name).ThenBy(entity => entity.Id).ToList());
+        await Task.FromResult<IReadOnlyCollection<TEntity>>(Items.Where(predicate.Compile())
+            .OrderBy(entity => entity.Name).ThenBy(entity => entity.Id).ToList()).ConfigureAwait(false);
 }


### PR DESCRIPTION
The PR also ensures repository implementations always use the `async`/`await` keyword instead of directly returning the `Task` as [recommended by David Fowler](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#prefer-asyncawait-over-directly-returning-task).

