### PR TITLE
Remove NuGet package security warning suppression

### DIFF
--- a/src/AppLibrary/AppLibrary.csproj
+++ b/src/AppLibrary/AppLibrary.csproj
@@ -38,7 +38,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" NoWarn="NU1903" />
+        <PackageReference Include="AutoMapper" />
         <PackageReference Include="GaEpd.GuardClauses" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
         <PackageReference Include="SonarAnalyzer.CSharp">


### PR DESCRIPTION
This warning should be handled by client applications after testing for vulnerable type maps. See [GHSA-rvv3-g6hj-g44x discussion · LuckyPennySoftware/AutoMapper · Discussion #4624](https://github.com/LuckyPennySoftware/AutoMapper/discussions/4624)